### PR TITLE
Add support for first-time deployments

### DIFF
--- a/cf_deploy.sh
+++ b/cf_deploy.sh
@@ -8,6 +8,7 @@ app=${1}
 org=${2}
 space=${3}
 manifest=${4:-manifest.yml}
+push_comand="push"
 
 if [[ -z $org || -z $space || -z $app ]]; then
   echo "Usage: $0  <app> <org> <space> [manifest.yml]" >&2
@@ -36,4 +37,11 @@ fi
 cf target -o "$org" -s "$space"
 
 # Deploy web-app
-cf zero-downtime-push "$app" -f "$manifest"
+# If the app already exists, switch to using the
+# zero-downtime-push with the autopilot plugin; otherwise
+# perform a normal push for a first time deployment.
+if cf app $app; then
+  push_command="zero-downtime-push"
+fi
+
+cf $push_command "$app" -f "$manifest"


### PR DESCRIPTION
Implements #8 

This changeset adds support to the deploy script for first-time deployments.  Previously, we were assuming an app was already deployed and performing the `zero-downtime-push` command of the autopilot plugin.  However, this will fail in the event that the app does not already exist, so this change defaults to performing a regular `push` command in the event the app is not already deployed.

h/t to @adborden for the suggested logic!