### PR TITLE
Refactor login and target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER kramos <markosrendell@gmail.com>
 # Install cloud foundry cli
 RUN apt-get update -y && \
     apt-get install -y curl && \
-    curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github" | tar xzv -C /usr/local/bin cf && \
+    curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar xzv -C /usr/local/bin cf && \
     cf install-plugin autopilot -f -r CF-Community
 
 COPY cf_deploy.sh /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ RUN apt-get update -y && \
     cf install-plugin autopilot -f -r CF-Community
 
 COPY cf_deploy.sh /usr/local/bin
+COPY cf_login_and_target.sh /usr/local/bin
 
 CMD cf -v

--- a/cf_deploy.sh
+++ b/cf_deploy.sh
@@ -20,21 +20,7 @@ if [[ ! -r "$manifest" ]]; then
   exit 1
 fi
 
-if [[ -n "$CF_API" ]]; then
-  cf api "$CF_API"
-fi
-
-(
-  set +x # Disable debugging
-
-  # Log in if necessary
-  if [[ -n $CF_DEPLOY_USER && -n $CF_DEPLOY_PASSWORD ]]; then
-    cf auth "$CF_DEPLOY_USER" "$CF_DEPLOY_PASSWORD"
-  fi
-)
-
-# Target space
-cf target -o "$org" -s "$space"
+cf_login_and_target.sh $org $space
 
 # Deploy web-app
 # If the app already exists, switch to using the

--- a/cf_login_and_target.sh
+++ b/cf_login_and_target.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -x
+
+org=${1}
+space=${2}
+
+if [[ -z $org || -z $space ]]; then
+  echo "Usage: $0 <org> <space>" >&2
+  exit 1
+fi
+
+if [[ -n "$CF_API" ]]; then
+  cf api "$CF_API"
+fi
+
+(
+  set +x # Disable debugging
+
+  # Log in if necessary
+  if [[ -n $CF_DEPLOY_USER && -n $CF_DEPLOY_PASSWORD ]]; then
+    cf auth "$CF_DEPLOY_USER" "$CF_DEPLOY_PASSWORD"
+  fi
+)
+
+# Target space
+cf target -o "$org" -s "$space"
+


### PR DESCRIPTION
This just factors the login-and-target step out into a separate command so the container can be used independent of a deploy (eg for running tasks, getting information, etc.) The interface of cg_deploy.sh is unchanged.